### PR TITLE
fix: `RuntimePerformanceTests` does not exist anymore

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -34,7 +34,7 @@ jobs:
         run: python -c "import pandas as pd; print(pd.__version__); import influxdb_client; print(influxdb_client.__version__)"
       - run: apt-get -q update && apt-get install -y libjemalloc-dev
       - name: Run benchmarks
-        run: cd RuntimePerformanceTests && swift package --allow-writing-to-package-directory benchmark --format influx --path benchmark-raw-output
+        run: swift package --allow-writing-to-package-directory benchmark --format influx --path benchmark-raw-output
       - name: Upload to Influx
         env:
           INFLUX_BUCKET_NAME: ${{ secrets.InfluxBucketName }}
@@ -42,4 +42,4 @@ jobs:
           INFLUX_ORG_NAME: ${{ secrets.InfluxOrgName }}
           INFLUX_URL: ${{ secrets.InfluxURL }}
           SWIFT_VERSION: ${{ matrix.swift }}
-        run: cd RuntimePerformanceTests && python benchmark-upload.py
+        run: python benchmark-upload.py


### PR DESCRIPTION
Manually run workflow: https://github.com/differentiable-swift/swift-differentiation-benchmarks/actions/runs/14886058151/job/41805856447