### PR TITLE
perf: custom VJP of `meanSquaredError` and make @inlinable

### DIFF
--- a/Benchmarks/ShallowWaterPDE/Solution.swift
+++ b/Benchmarks/ShallowWaterPDE/Solution.swift
@@ -43,8 +43,8 @@ struct Solution: Differentiable {
     func evolve() -> Self {
         var newWaterLevel = currentWaterLevel
 
-        for x in 1 ..< resolution - 1 {
-            for y in 1 ..< resolution - 1 {
+        for y in 1 ..< resolution - 1 {
+            for x in 1 ..< resolution - 1 {
                 // FIXME: Should be u2[x][y] = ...
                 let newValue: Float = 2 * currentWaterLevel[x, y] + (c * c * dt * dt + c * a * dt) * currentWaterLevel.laplace(x, y) * Float(resolution * resolution) - previousWaterLevel[x, y] - c * a * dt * previousWaterLevel.laplace(x, y) * Float(resolution * resolution)
                 newWaterLevel[x, y] = newValue

--- a/Benchmarks/ShallowWaterPDE/Storage+Float.swift
+++ b/Benchmarks/ShallowWaterPDE/Storage+Float.swift
@@ -33,16 +33,24 @@ extension Array2DStorage where Element == Float {
     ) {
         let value = self.meanSquaredError(to: target)
         let scale: Float = 2.0 / Float(width * height)
+        let width = self.width
+        let height = self.height
 
         return (
             value: value,
             pullback: { v in
-                var gradient = self
-                for x in 0..<self.width {
-                    for y in 0..<self.height {
-                        gradient[x, y] = v * scale * (self[x, y] - target[x, y])
+                let gradient = Array2DStorage<Float.TangentVector>(
+                    unsafeUninitializedWidth: width,
+                    unsafeUninitializedHeight: height,
+                    initializingWith: { buffer, initializedCount in
+                        initializedCount = width * height
+                        for y in 0..<height {
+                            for x in 0..<width {
+                                buffer[x + y*width] = v * scale * (self[x, y] - target[x, y])
+                            }
+                        }
                     }
-                }
+                )
                 return gradient
             }
         )

--- a/Benchmarks/ShallowWaterPDE/Storage+Float.swift
+++ b/Benchmarks/ShallowWaterPDE/Storage+Float.swift
@@ -16,8 +16,8 @@ extension Array2DStorage where Element == Float {
     func meanSquaredError(to target: Array2DStorage<Float>) -> Float {
         var mse: Float = 0.0
 
-        for x in 0 ..< withoutDerivative(at: width) {
-            for y in 0 ..< withoutDerivative(at: height) {
+        for y in 0 ..< withoutDerivative(at: height) {
+            for x in 0 ..< withoutDerivative(at: width) {
                 let error = target[x, y] - self[x, y]
                 mse += error * error
             }

--- a/Benchmarks/ShallowWaterPDE/Storage.swift
+++ b/Benchmarks/ShallowWaterPDE/Storage.swift
@@ -38,6 +38,17 @@ extension Array2DStorage {
         self.height = height
         self.values = .init(repeating: element, count: width * height)
     }
+
+    @inlinable
+    init(
+        unsafeUninitializedWidth width: Int,
+        unsafeUninitializedHeight height: Int,
+        initializingWith initializer: (inout UnsafeMutableBufferPointer<Element>, inout Int) -> Void
+    ) {
+        self.width = width
+        self.height = height
+        self.values = .init(unsafeUninitializedCapacity: width * height, initializingWith: initializer)
+    }
 }
 
 extension Array2DStorage: Equatable where Element: Equatable { }


### PR DESCRIPTION
I noticed a whole lot of 10.0 kB mallocs and some unspecialized reverse mode derivatives when running the benchmark under the allocations profiler.
$\text{resolution} = 50 \implies \text{count} = 50 \times 50 \times 4 = 10^4$
```
╒══════════════════════════════════════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╕
│         Time (wall clock) (ms) *         │        p0 │       p25 │       p50 │       p75 │       p90 │       p99 │      p100 │   Samples │
╞══════════════════════════════════════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╡
│                  alpha                   │      1813 │      1818 │      1821 │      1832 │      1839 │      1856 │      1856 │        20 │
├──────────────────────────────────────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┤
│                betterMSE                 │      1356 │      1362 │      1366 │      1377 │      1387 │      1389 │      1389 │        20 │
├──────────────────────────────────────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┤
│                    Δ                     │      -457 │      -456 │      -455 │      -455 │      -452 │      -467 │      -467 │         0 │
├──────────────────────────────────────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┤
│              Improvement %               │        25 │        25 │        25 │        25 │        25 │        25 │        25 │         0 │
╘══════════════════════════════════════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╛

╒══════════════════════════════════════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╕
│           Malloc (total) (M) *           │        p0 │       p25 │       p50 │       p75 │       p90 │       p99 │      p100 │   Samples │
╞══════════════════════════════════════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╡
│                  alpha                   │        18 │        18 │        18 │        18 │        18 │        18 │        18 │        20 │
├──────────────────────────────────────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┤
│                betterMSE                 │        10 │        10 │        10 │        10 │        10 │        10 │        10 │        20 │
├──────────────────────────────────────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┤
│                    Δ                     │        -8 │        -8 │        -8 │        -8 │        -8 │        -8 │        -8 │         0 │
├──────────────────────────────────────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┤
│              Improvement %               │        44 │        44 │        44 │        44 │        44 │        44 │        44 │         0 │
╘══════════════════════════════════════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╛
```

The following difference in number of heap allocations was observed with the custom derivative, but WITHOUT `@inlinable`
### Before
<img width="4910" height="496" alt="image" src="https://github.com/user-attachments/assets/69d151c9-bc7b-4bc6-9365-87cacad79746" />

### After
<img width="4912" height="508" alt="image" src="https://github.com/user-attachments/assets/ed391506-8bd6-4e46-90f1-56e32ca80758" />

## Custom VJP vs Compiler-Synthesized VJP
Should be correct
https://godbolt.org/z/TTcareE31
